### PR TITLE
Update creatures-aoe3.json

### DIFF
--- a/data/bestiary/creatures-aoe3.json
+++ b/data/bestiary/creatures-aoe3.json
@@ -1654,7 +1654,178 @@
 			]
 		},
 		{
-			"name": "Gang Tough",
+			"name": "Washboard Dog Tough",
+			"isNpc": false,
+			"source": "AoE3",
+			"page": 8,
+			"level": 7,
+			"rarity": "Uncommon",
+			"alignment": "N",
+			"size": "Medium",
+			"traits": [
+				"Human"
+			],
+			"creatureType": [
+				"Humanoid"
+			],
+			"perception": {
+				"default": 17
+			},
+			"languages": {
+				"languages": [
+					"Common"
+				],
+				"languageAbilities": []
+			},
+			"skills": {
+				"Athletics": {
+					"default": 17
+				},
+				"Intimidation": {
+					"default": 13
+				},
+				"Gang Lore": {
+					"default": 13
+				}
+			},
+			"abilityMods": {
+				"Str": 4,
+				"Dex": 3,
+				"Con": 4,
+				"Int": 0,
+				"Wis": 2,
+				"Cha": 0
+			},
+			"items": [
+				"+1 morningstar",
+				"chain shirt",
+				"heavy crossbow with 10 bolts",
+				"steel shield"
+			],
+			"abilitiesTop": [],
+			"ac": {
+				"default": 25,
+				"abilities": null
+			},
+			"savingThrows": {
+				"Fort": {
+					"default": 17
+				},
+				"Ref": {
+					"default": 16
+				},
+				"Will": {
+					"default": 13
+				},
+				"abilities": null
+			},
+			"hp": [
+				{
+					"hp": 125,
+					"note": null,
+					"abilities": null
+				}
+			],
+			"abilitiesMid": [
+				{
+					"activity": {
+						"number": 1,
+						"unit": "reaction"
+					},
+					"entries": [],
+					"name": "Shield Block",
+					"generic": true
+				}
+			],
+			"speed": {
+				"abilities": null,
+				"walk": 25
+			},
+			"attacks": [
+				{
+					"range": "Melee",
+					"name": "morningstar",
+					"attack": 18,
+					"traits": [
+						"magical",
+						"versatile P"
+					],
+					"effects": [],
+					"damage": "{@damage 1d6+8} bludgeoning",
+					"types": [
+						"bludgeoning"
+					]
+				},
+				{
+					"range": "Melee",
+					"name": "shield bash",
+					"attack": 18,
+					"traits": null,
+					"effects": [],
+					"damage": "{@damage 1d4+6} bludgeoning",
+					"types": [
+						"bludgeoning"
+					]
+				},
+				{
+					"range": "Ranged",
+					"name": "heavy crossbow",
+					"attack": 16,
+					"traits": [
+						"range increment 120 feet",
+						"reload 2"
+					],
+					"effects": [],
+					"damage": "{@damage 1d10} piercing",
+					"types": [
+						"piercing"
+					]
+				}				
+			],
+			"abilitiesBot": [
+				{
+					"entries": [
+						"Whenever the gang tough makes a successful melee {@action Strike} against a {@condition frightened} creature, the {@action Strike} deals an extra weapon die of damage."
+					],
+					"name": "Bullyrag Beatdown"
+				},
+				{
+					"entries": [
+						"When the gang tough's {@action Strike} with a bludgeoning weapon is a critical hit and deals damage, the target becomes {@condition frightened|CRB|frightened 1}."
+					],
+					"name": "Frightening Critical"
+				},
+				{
+					"activity": {
+						"number": 1,
+						"unit": "action"
+					},
+					"traits": [
+						"auditory",
+						"manipulate"
+					],
+					"entries": [
+						"The Washboard Dog scrapes their weapon up and down their washboard shield, making such a clatter that it’s hard to hear anything over the din. Until the beginning of the Washboard Dog tough’s next turn, all creatures within 30 feet gain a +1 circumstance bonus to any saves to resist auditory spells or abilities."
+					],
+					"name": "Scraping Clamor"
+				}
+			],
+			"inflicts": {
+				"damage": [
+					"bludgeoning"
+				],
+				"condition": [
+					"{@condition frightened}"
+				]
+			},
+			"misc": [
+				"MA",
+				"CC",
+				"UW"
+			]
+		},
+		{
+			"name": "Diobel Sweeper Tough",
 			"isNpc": false,
 			"source": "AoE3",
 			"page": 8,
@@ -1698,11 +1869,14 @@
 			},
 			"items": [
 				"+1 morningstar",
-				"additional items (see below)"
+				"moderate bottled lightning (2)",
+				"moderate frost vials (2)",
+				"sling (with 3 spellstrike bullets [type I, magic missile]",
+				"moderate tanglefoot bag"
 			],
 			"abilitiesTop": [],
 			"ac": {
-				"default": 25,
+				"default": 24,
 				"abilities": null
 			},
 			"savingThrows": {
@@ -1710,7 +1884,7 @@
 					"default": 17
 				},
 				"Ref": {
-					"default": 16
+					"default": 17
 				},
 				"Will": {
 					"default": 13
@@ -1743,26 +1917,63 @@
 					"types": [
 						"bludgeoning"
 					]
+				},
+				{
+					"range": "Ranged",
+					"name": "sling",
+					"attack": 17,
+					"traits": [
+						"range increment 50 feet",
+						"propulsive",
+						"reload 1"
+					],
+					"effects": [],
+					"damage": "{@damage 1d6+6} bludgeoning plus {@damage 3d4+3 force}",
+					"types": [
+						"bludgeoning",
+						"force"
+					]
+				},
+				{
+					"range": "Ranged",
+					"name": "bomb",
+					"attack": 19,
+					"traits": [
+						"alchemical",
+						"bomb",
+						"range increment 30 feet"
+					],
+					"effects": [],
+					"damage": "{@damage 2d6} cold or electricity plus 2 splash",
+					"types": [
+						"cold",
+						"electricity",
+						"splash"
+					]
 				}
 			],
 			"abilitiesBot": [
 				{
 					"entries": [
-						"Whenever the gang tough makes a successful melee {@action Strike} against a {@condition frightened} creature,"
+						"Whenever the gang tough makes a successful melee {@action Strike} against a {@condition frightened} creature, the {@action Strike} deals an extra weapon die of damage."
 					],
 					"name": "Bullyrag Beatdown"
-				},
-				{
-					"entries": [
-						"{@action Strike} deals an extra weapon die of damage."
-					],
-					"name": "the"
 				},
 				{
 					"entries": [
 						"When the gang tough's {@action Strike} with a bludgeoning weapon is a critical hit and deals damage, the target becomes {@condition frightened|CRB|frightened 1}."
 					],
 					"name": "Frightening Critical"
+				},
+				{
+					"activity": {
+						"number": 1,
+						"unit": "action"
+					},
+					"entries": [
+						"The Diobel Sweeper tough Interacts to draw a bomb, then Strikes with it."
+					],
+					"name": "Quick Bomber"
 				}
 			],
 			"inflicts": {


### PR DESCRIPTION
The "Gang Tough" Bestiary entry should be two separate entries: "Washboard Dog Tough" and "Diobel Sweeper Tough".
Also fixed a typo/format error for "Bullyrag Beatdown" ability.